### PR TITLE
Allow modifying the configmaps, namely 'vcloud-csi-configmap' one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed username/credentials from authentication options to match [cluster chart](https://github.com/giantswarm/cluster-cloud-director/pull/35).
+- Changed the default value of `global.vcdConfig.immutable` from `false` -> `true`.
+- Add quoting for storage profiles in the StorageClass resources.
 
 ## [0.1.2] - 2022-09-08
 

--- a/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/storage-class.yaml
+++ b/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/storage-class.yaml
@@ -11,7 +11,7 @@ metadata:
 provisioner: named-disk.csi.cloud-director.vmware.com
 reclaimPolicy: Delete
 parameters:
-  storageProfile: {{ .delete.vcdStorageProfileName }}
+  storageProfile: {{ .delete.vcdStorageProfileName | quote }}
   filesystem: {{ .delete.fileSystem }}
 ---
 kind: StorageClass
@@ -25,7 +25,7 @@ metadata:
 provisioner: named-disk.csi.cloud-director.vmware.com
 reclaimPolicy: Retain
 parameters:
-  storageProfile: {{ .retain.vcdStorageProfileName }}
+  storageProfile: {{ .retain.vcdStorageProfileName | quote }}
   filesystem: {{ .retain.fileSystem }}
 {{- end }}
 {{- end }}

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -15,7 +15,7 @@ global:
     oneArm:
       startIP: "192.168.8.2"  # Will disappear in future versions
       endIP: "192.168.8.100"  # Will disappear in future versions
-    immutable: true
+    immutable: false  # Associated configmaps will use this flag
 
 cloud-director-named-disk-csi-driver:
   basicAuthSecret:


### PR DESCRIPTION

Related issue: https://github.com/giantswarm/giantswarm/issues/24776
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- changes the default value of `global.vcdConfig.immutable` from `false` -> `true`
- add quotes for storage profile to fix

```
error validating "": error validating data: unknown object type "nil" in StorageClass.parameters.storageProfile
```

note: the actual # of changed lines in was only 2, the reason why it shows the whole file (storage-class.yaml) was changed is that there were `CRLF` used as `"EOLs"`. Use this for better code review experience: https://github.com/giantswarm/cloud-provider-cloud-director-app/pull/21/files?diff=unified&w=1

### Testing

```
λ k describe app glados-cloud-provider-cloud-director -n org-giantswarm | grep Reason
    Reason:         Release has failed 5 times.
Reason: Upgrade "cloud-provider-cloud-director" failed: cannot patch "vcloud-ccm-configmap" with kind ConfigMap: ConfigMap "vcloud-ccm-configmap" is invalid: data: Forbidden: field is immutable when `immutable` is set
^ should be gone
```

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
