### PR TITLE
Add network policy for csi-vcd-controllerplugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add network policy for csi-vcd-controllerplugin to access cloud-director api.
+
 ## [0.2.1] - 2023-02-20
 
 ### Changed

--- a/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/network-policy.yaml
+++ b/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/network-policy.yaml
@@ -1,0 +1,16 @@
+# Allow csi-vcd-controllerplugin to access world (cloud-director api)
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: csi-vcd-controllerplugin
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: csi-vcd-controllerplugin
+  egress:
+  - {}
+  policyTypes:
+  - Egress


### PR DESCRIPTION
CSI needs to access cloud-director api but it is blocked by existing network policies. This PR adds a network policy for CSI.

Note that CPI runs in host network and it doesn't require a network policy.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
