### PR TITLE
add support for enableVirtualServiceSharedIP.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `enableVirtualServiceSharedIP`.
+
 ## [0.2.2] - 2023-02-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ The storageProfile field corresponds to the Storage Policy in VMware Cloud Direc
 
 When you create a PV, it will appear under Named disks where you can find which VM it is connected to.
 
+## Notes on `enableVirtualServiceSharedIP`
+
+There are 3 possible scenarios for this setting:
+
+- `enableVirtualServiceSharedIP: true` and `oneArm.enabled: false`
+
+A service type load balancer with multiple ports creates virtual services that share an IP from the Edge external pool. The environment must support virtual service shared IP (VCD 10.4 or xxx flag in AVI load balancer).
+
+- `enableVirtualServiceSharedIP: true` and `oneArm.enabled: true`
+
+A service type load balancer with multiple ports creates virtual services that share an internal IP (usually 192.168.8.x) with a NAT rule to map an IP from the Edge external pool to the internal IP. The environment must support virtual service shared IP (VCD 10.4 or xxx flag in AVI load balancer).
+
+- `enableVirtualServiceSharedIP: false` and `oneArm.enabled: true | false`
+
+A service type load balancer with multiple ports creates virtual services with different internal IPs (usually 192.168.8.x) with NAT rules to map an IP from the Edge external pool to the internal IPs. Compatible with versions older than VCD 10.4.
+
 ## How are the charts created
 
 There are no upstream charts available so these charts are created manually based on the upstream manifests.

--- a/helm/cloud-provider-cloud-director/charts/cloud-provider-for-cloud-director/templates/configmap.yaml
+++ b/helm/cloud-provider-cloud-director/charts/cloud-provider-for-cloud-director/templates/configmap.yaml
@@ -15,9 +15,12 @@ data:
     loadbalancer:
       network: {{ .ovdcNetwork }}
       vipSubnet: {{ .vipSubnet }}
+      enableVirtualServiceSharedIP: {{ .enableVirtualServiceSharedIP }}
+      {{- if or (.oneArm.enabled) (not .enableVirtualServiceSharedIP) }}
       oneArm:
         startIP: {{ .oneArm.startIP }}
         endIP: {{ .oneArm.endIP }}
+      {{- end }}
       ports:
         http: 80
         https: 443

--- a/helm/cloud-provider-cloud-director/values.schema.json
+++ b/helm/cloud-provider-cloud-director/values.schema.json
@@ -160,6 +160,9 @@
                         "oneArm": {
                             "type": "object",
                             "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
                                 "endIP": {
                                     "type": "string"
                                 },

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -11,10 +11,11 @@ global:
     vipSubnet: ""  # Virtual IP CIDR for the external network
     clusterid: ""  # "Infra Id" field of VCDCluster object in management cluster
     vAppName: ""
-    enableVirtualServiceSharedIP: false  # supported for VCD >= 10.4 - not used yet
+    enableVirtualServiceSharedIP: false  # Multiple VS can share an IP if true.
     oneArm:
-      startIP: "192.168.8.2"  # Will disappear in future versions
-      endIP: "192.168.8.100"  # Will disappear in future versions
+      enabled: true  # Creates a NAT rule instead of direct LB IP if true.
+      startIP: "192.168.8.2"
+      endIP: "192.168.8.100"
     immutable: false  # Associated configmaps will use this flag
 
 cloud-director-named-disk-csi-driver:


### PR DESCRIPTION
This PR:

- Adds support for `enableVirtualServiceSharedIP` which allows to share an IP across virtual services as opposed to using a DNAT rule to forward to multiple virtual service IPs.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
