### PR TITLE
Set enable virtual service shared ip to default true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `enableVirtualServiceSharedIP` default value to `true` and `oneArm.enabled` to `false`.
+
 ## [0.2.3] - 2023-02-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ When you create a PV, it will appear under Named disks where you can find which 
 
 There are 3 possible scenarios for this setting:
 
-- `enableVirtualServiceSharedIP: true` and `oneArm.enabled: false`
+- `enableVirtualServiceSharedIP: true` and `oneArm.enabled: false` **(default value)**
 
 A service type load balancer with multiple ports creates virtual services that share an IP from the Edge external pool. The environment must support virtual service shared IP (VCD 10.4 or xxx flag in AVI load balancer).
 

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -11,9 +11,9 @@ global:
     vipSubnet: ""  # Virtual IP CIDR for the external network
     clusterid: ""  # "Infra Id" field of VCDCluster object in management cluster
     vAppName: ""
-    enableVirtualServiceSharedIP: false  # Multiple VS can share an IP if true.
+    enableVirtualServiceSharedIP: true  # Multiple VS can share an IP if true.
     oneArm:
-      enabled: true  # Creates a NAT rule instead of direct LB IP if true.
+      enabled: false  # Creates a NAT rule instead of direct LB IP if true.
       startIP: "192.168.8.2"
       endIP: "192.168.8.100"
     immutable: false  # Associated configmaps will use this flag


### PR DESCRIPTION
This PR:

- Changes the default behaviour of the load balancer (`enableVirtualServiceSharedIP: true` and `oneArm.enabled: false`).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
