### PR TITLE
consume upstream images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Switch all images to Azure CR.
+- Consume retagged upstream images of cpi and csi.
 
 ## [0.2.10] - 2024-02-13
 

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -29,15 +29,15 @@ cloud-director-named-disk-csi-driver:
     csiProvisioner:
       image: gsoci.azurecr.io/giantswarm/csi-provisioner
     csiPlugin:
-      image: gsoci.azurecr.io/giantswarm/csi-cloud-director
-      tag: 1.3.2.68f48f4
+      image: gsoci.azurecr.io/giantswarm/cloud-director-named-disk-csi-driver
+      tag: 1.5.0
 
   nodeDaemonset:
     nodeDriverRegistrar:
       image: gsoci.azurecr.io/giantswarm/csi-node-driver-registrar
     csiPlugin:
-      image: gsoci.azurecr.io/giantswarm/csi-cloud-director
-      tag: 1.3.2.68f48f4
+      image: gsoci.azurecr.io/giantswarm/cloud-director-named-disk-csi-driver
+      tag: 1.5.0
 
   storageClass:
     enabled: true
@@ -52,8 +52,8 @@ cloud-director-named-disk-csi-driver:
 
 cloud-provider-for-cloud-director:
   ccmDeployment:
-    image: gsoci.azurecr.io/giantswarm/cpi-cloud-director
-    tag: "1.2.0-de4b612"
+    image: gsoci.azurecr.io/giantswarm/cloud-provider-for-cloud-director
+    tag: 1.6.0
 
 containerSecurityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3463

Consumed by https://github.com/giantswarm/cluster-cloud-director/pull/307