### PR TITLE
ip space rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rollback CPI from `1.6.0` to `1.5.0` due to IP Spaces incompatibility.
+
 ## [0.2.11] - 2024-05-30
 
 ### Changed

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -53,7 +53,7 @@ cloud-director-named-disk-csi-driver:
 cloud-provider-for-cloud-director:
   ccmDeployment:
     image: gsoci.azurecr.io/giantswarm/cloud-provider-for-cloud-director
-    tag: 1.6.0
+    tag: 1.5.0
 
 containerSecurityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION

Towards https://github.com/giantswarm/giantswarm/issues/31349

The CAPVCD CPI requires specific permissions to check if IP Spaces are set. We currently don't have that permission so creating an LB fails (pending).

2 possible fixes:

Rollback to 1.5.0
Ensure VCD @ 10.4.3+ and permissions added to user role