### PR TITLE
update cpi to 1.6.1-gs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to `1.6.1-gs` of CPI. This includes [upstream version `1.6.1`](https://github.com/vmware/cloud-provider-for-cloud-director/releases/tag/1.6.1) plus [this unreleased patch](https://github.com/vmware/cloud-provider-for-cloud-director/pull/376) of CPI to address LB health monitor upgrade issue.
+
 ## [0.4.0] - 2025-02-06
 
 ### Changed

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -53,7 +53,7 @@ cloud-director-named-disk-csi-driver:
 cloud-provider-for-cloud-director:
   ccmDeployment:
     image: gsoci.azurecr.io/giantswarm/cloud-provider-for-cloud-director
-    tag: 1.6.0-gs
+    tag: 1.6.1-gs
 
 containerSecurityContext:
   allowPrivilegeEscalation: false


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/32585

This PR upgrades the cpi to upstream version 1.6.1, namely including https://github.com/vmware/cloud-provider-for-cloud-director/pull/375 which hopefully addresses issues we have seen regarding creation of lb services without ips specifically set.
It also includes our custom patch which has not yet been released upstream. https://github.com/vmware/cloud-provider-for-cloud-director/pull/376
<!--
Not all PRs will require all tests to be carried out. Delete where appropriate.
-->

<!--
MODIFY THIS AFTER your new app repo is in https://github.com/giantswarm/github
@team-halo-engineers will be automatically requested for review once
this PR has been submitted. (But not for drafts)
-->

This PR:

- adds/changes/removes etc

### Testing

Description on how {APP-NAME} can be tested.

- [ ] fresh install works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM
- [ ] upgrade from previous version works
  - [ ] AWS
  - [ ] Azure
  - [ ] KVM

#### Other testing

Description of features to additionally test for {APP-NAME} installations.

- [ ] check reconciliation of existing resources after upgrading
- [ ] X still works after upgrade
- [ ] Y is installed correctly

<!--
Changelog must always be updated.
-->

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
