### PR TITLE
Update csi to 1.6.0 and drop `--v=5` from csi plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to `1.6.1-gs` of CPI. This includes [upstream version `1.6.1`](https://github.com/vmware/cloud-provider-for-cloud-director/releases/tag/1.6.1) plus [this unreleased patch](https://github.com/vmware/cloud-provider-for-cloud-director/pull/376) of CPI to address LB health monitor upgrade issue.
+- Update to `1.6.0` of CSI. This also removes `--v=5` from the CSI plugin as this flag is no longer supported in this version.
 
 ## [0.4.0] - 2025-02-06
 

--- a/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/controllerplugin-statefulset.yaml
+++ b/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/controllerplugin-statefulset.yaml
@@ -71,7 +71,6 @@ spec:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
             - --endpoint=$(CSI_ENDPOINT)
-            - --v=5
           env:
             - name: NODE_ID
               valueFrom:

--- a/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/nodeplugin-daemonset.yaml
+++ b/helm/cloud-provider-cloud-director/charts/cloud-director-named-disk-csi-driver/templates/nodeplugin-daemonset.yaml
@@ -57,7 +57,6 @@ spec:
             - --nodeid=$(NODE_ID)
             - --endpoint=$(CSI_ENDPOINT)
             - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
-            - --v=5
           env:
             - name: NODE_ID
               valueFrom:

--- a/helm/cloud-provider-cloud-director/values.yaml
+++ b/helm/cloud-provider-cloud-director/values.yaml
@@ -30,14 +30,14 @@ cloud-director-named-disk-csi-driver:
       image: gsoci.azurecr.io/giantswarm/csi-provisioner
     csiPlugin:
       image: gsoci.azurecr.io/giantswarm/cloud-director-named-disk-csi-driver
-      tag: 1.5.0
+      tag: 1.6.0
 
   nodeDaemonset:
     nodeDriverRegistrar:
       image: gsoci.azurecr.io/giantswarm/csi-node-driver-registrar
     csiPlugin:
       image: gsoci.azurecr.io/giantswarm/cloud-director-named-disk-csi-driver
-      tag: 1.5.0
+      tag: 1.6.0
 
   storageClass:
     enabled: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/32599

CSI version `1.6.0` is required with VCD 10.6 as API v36 has been removed.

the `--v` flag must be removed from the CSI plugins because it no longer works with that version:

```
Error: unknown flag: --v
Usage:
  /opt/vcloud/bin/cloud-director-named-disk-csi-driver [flags]
```